### PR TITLE
Any new private releases will include the datapack file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
     - id: release
       uses: pozetroninc/github-action-get-latest-release@master
       with:
+        token: ${{ secrets.GITHUB_TOKEN }}
         repository: ${{ github.repository }}
     # zip the file
     - name: Create Zip Folder


### PR DESCRIPTION
Future bug IF repo were to be private, uses github token to get the current version tag.